### PR TITLE
Fix 'bash: /trans: No such file or directory' error

### DIFF
--- a/trad-functions/search_word_using_google_script.sh
+++ b/trad-functions/search_word_using_google_script.sh
@@ -4,7 +4,7 @@ search_word_using_google_script()
 {
   word=$1
   printf "\n${YELLOW}I´m gonna look using google-translation script, brief option"
-  spanish_word_using_trans=$(bash ${TRAD3_PATH}/trans -b :es ${word} | cut -f 1 -d " ")
+  spanish_word_using_trans=$(trans -b :es ${word} | cut -f 1 -d " ")
   if [ "${word}" = "${spanish_word_using_trans}" ]
   then
       printf "\nIt seems the word you are looking for It is the same as spanish word"


### PR DESCRIPTION
Removed the undefined TRAD3_PATH variable which caused the script to look for 'trans' at the root path '/trans' using bash. It now calls 'trans' directly, leveraging the system's PATH where it is already installed.